### PR TITLE
관리자 계정 RUD 기능 추가

### DIFF
--- a/src/main/java/com/schnofiticationbe/controller/AdminController.java
+++ b/src/main/java/com/schnofiticationbe/controller/AdminController.java
@@ -64,4 +64,27 @@ public class AdminController {
     public ResponseEntity<List<Department>> getAllDepartment() {
         return ResponseEntity.ok(adminService.getAllDepartment());
     }
+
+    @GetMapping("/my-info")
+    public ResponseEntity<AdminDto.MyInfoResponse> getMyInfo(
+            @RequestHeader("Authorization") String authorization
+    ) {
+        return ResponseEntity.ok(adminService.getMyInfo(authorization));
+    }
+
+    @PutMapping("/my-info")
+    public ResponseEntity<AdminDto.MyInfoResponse> updateMyInfo(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody AdminDto.UpdateRequest req
+    ) {
+        return ResponseEntity.ok(adminService.updateMyInfo(authorization, req));
+    }
+
+    @DeleteMapping("/my-info")
+    public ResponseEntity<AdminDto.DeleteResponse> deleteMyInfo(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody AdminDto.DeleteRequest req
+    ) {
+        return ResponseEntity.ok(adminService.deleteMyInfo(authorization, req));
+    }
 }

--- a/src/main/java/com/schnofiticationbe/dto/AdminDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/AdminDto.java
@@ -2,6 +2,7 @@ package com.schnofiticationbe.dto;
 
 import com.schnofiticationbe.entity.Admin;
 import com.schnofiticationbe.entity.InternalNotice;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -75,5 +76,37 @@ public class AdminDto {
             this.userId = userId;
             this.tempPassword = tempPassword;
         }
+    }
+
+    public record MyInfoResponse(
+            String name,
+            String affiliation
+    ) {
+        public MyInfoResponse(Admin admin) {
+            this(
+                    admin.getName(),
+                    admin.getAffiliation()
+            );
+        }
+    }
+
+    @Getter @Setter
+    public static class UpdateRequest {
+        private String name;
+        private String affiliation;
+        private String password;
+        private String registerPassword;
+    }
+
+    @Getter @Setter
+    public static class DeleteRequest {
+        private String registerPassword;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class DeleteResponse {
+        private String message;
     }
 }


### PR DESCRIPTION
## 변경 사항 (3파일)
### Controller
- GET /admin/my-info : 내 정보 조회 (JWT 기반)
- PUT /admin/my-info : 내 정보 수정 (보안 비밀번호 확인 후 이름, 소속, 비밀번호 수정 가능)
- DELETE /admin/my-info : 내 계정 삭제 (보안 비밀번호 확인 후 삭제)

### Service
- getMyInfo(jwtToken)
- updateMyInfo(jwtToken, UpdateRequest)
- deleteMyInfo(jwtToken, DeleteRequest)

### DTO
- MyInfoResponse : name, affiliation만 반환
- UpdateRequest : name, affiliation, password, registerPassword 포함
- DeleteRequest : registerPassword 포함
- DeleteResponse : "계정이 삭제되었습니다." 메시지 반환
