### PR TITLE
feat : 카테고리 종류 조회 api 추가 및 카카오톡 정보 CRUD 추가

### DIFF
--- a/src/main/java/com/schnofiticationbe/controller/KakaoRoomInfoController.java
+++ b/src/main/java/com/schnofiticationbe/controller/KakaoRoomInfoController.java
@@ -1,0 +1,59 @@
+package com.schnofiticationbe.controller;
+
+import com.fasterxml.jackson.core.util.ReadConstrainedTextBuffer;
+import com.schnofiticationbe.dto.KakaoRoomInfoDto;
+import com.schnofiticationbe.entity.InternalNotice;
+import com.schnofiticationbe.service.KakaoRoomInfoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jdk.jfr.Description;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.management.DescriptorKey;
+import java.util.List;
+
+@RestController
+@RequestMapping("/kakao")
+@RequiredArgsConstructor
+public class KakaoRoomInfoController {
+    private final KakaoRoomInfoService kakaoRoomInfoService;
+
+    // 생성
+    @PostMapping
+    public ResponseEntity<KakaoRoomInfoDto.KakaoRoomInfoResponse> createRoom(@RequestBody KakaoRoomInfoDto.CreateKakaoRoomInfoRequest request) {
+        KakaoRoomInfoDto.KakaoRoomInfoResponse createdRoom = kakaoRoomInfoService.createKakaoRoomInfo(request);
+        return ResponseEntity.ok(createdRoom);
+    }
+
+    @Tag(name = "카카오톡방 조회", description = "room_id를 이용해서 카카오톡 방 정보 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<KakaoRoomInfoDto.KakaoRoomInfoResponse> getRoomById(@PathVariable Long id) {
+        return ResponseEntity.ok(kakaoRoomInfoService.findKakaoRoomInfoById(id));
+    }
+
+    // 업데이트
+    @PutMapping("/{id}")
+    public ResponseEntity<KakaoRoomInfoDto.KakaoRoomInfoResponse> updateRoom(@PathVariable Long id, @RequestBody KakaoRoomInfoDto.UpdateKakaoRoomInfoRequest request) {
+        KakaoRoomInfoDto.KakaoRoomInfoResponse updatedRoom = kakaoRoomInfoService.updateKakaoRoomInfo(id, request);
+        return ResponseEntity.ok(updatedRoom);
+    }
+
+    // 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRoom(@PathVariable Long id) {
+        kakaoRoomInfoService.deleteKakaoRoomInfo(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Tag(name = "필터링한 카카오톡 방 정보 조회", description = "학과, 학년 또는 전체를 필터링해 카카오톡 방 정보 조회")
+    @GetMapping
+    public ResponseEntity<List<KakaoRoomInfoDto.KakaoRoomInfoResponse>> getRoomsByFilter(
+            @RequestParam(required = false) Long lessonId,
+            @RequestParam(required = false) InternalNotice.TargetYear  targetyear
+    ) {
+        List<KakaoRoomInfoDto.KakaoRoomInfoResponse> rooms = kakaoRoomInfoService.findRoomsByCriteria(targetyear, lessonId);
+        return ResponseEntity.ok(rooms);
+    }
+}

--- a/src/main/java/com/schnofiticationbe/controller/SourceController.java
+++ b/src/main/java/com/schnofiticationbe/controller/SourceController.java
@@ -1,20 +1,15 @@
 package com.schnofiticationbe.controller;
 
-<<<<<<< HEAD
-=======
 import com.schnofiticationbe.dto.CategoryDto;
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
-import com.schnofiticationbe.entity.Category;
 import com.schnofiticationbe.service.CategoryService;
 import com.schnofiticationbe.service.CrawlPostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Locale;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -23,16 +18,7 @@ public class SourceController {
     private final CategoryService categoryService;
     //전체 카테고리 종류 조회
     @GetMapping("/tag")
-<<<<<<< HEAD
-    public ResponseEntity<List<String>> getTags() {
-        List<Category> categories = categoryService.getAllCategories();
-        List<String> tags = categories.stream()
-                .map(category -> category.getCategoryName().toLowerCase(Locale.ROOT))
-                .toList();
-        return ResponseEntity.ok(tags);
-=======
-    public ResponseEntity<List<CategoryDto.CategoryResponse>> getAllTags(){
+    public ResponseEntity<List<CategoryDto.CategoryResponse>> getAllTags() {
         return ResponseEntity.ok(categoryService.getAllCategories());
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     }
 }

--- a/src/main/java/com/schnofiticationbe/controller/SourceController.java
+++ b/src/main/java/com/schnofiticationbe/controller/SourceController.java
@@ -1,5 +1,7 @@
 package com.schnofiticationbe.controller;
 
+import com.schnofiticationbe.entity.Category;
+import com.schnofiticationbe.service.CategoryService;
 import com.schnofiticationbe.service.CrawlPostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,15 +10,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequiredArgsConstructor
 public class SourceController {
     private final CrawlPostService crawlPostService;
-    //전체 학과 조회
-    @GetMapping("/department" )
-    public ResponseEntity<List<String>> getDepartments() {
-        List<String> departments = crawlPostService.getAllDepartments();
-        return ResponseEntity.ok(departments);
+    private final CategoryService categoryService;
+    //전체 카테고리 종류 조회
+    @GetMapping("/tag")
+    public ResponseEntity<List<String>> getTags() {
+        List<Category> categories = categoryService.getAllCategories();
+        List<String> tags = categories.stream()
+                .map(category -> category.getCategoryName().toLowerCase(Locale.ROOT))
+                .toList();
+        return ResponseEntity.ok(tags);
     }
 }

--- a/src/main/java/com/schnofiticationbe/controller/SourceController.java
+++ b/src/main/java/com/schnofiticationbe/controller/SourceController.java
@@ -1,5 +1,9 @@
 package com.schnofiticationbe.controller;
 
+<<<<<<< HEAD
+=======
+import com.schnofiticationbe.dto.CategoryDto;
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 import com.schnofiticationbe.entity.Category;
 import com.schnofiticationbe.service.CategoryService;
 import com.schnofiticationbe.service.CrawlPostService;
@@ -19,11 +23,16 @@ public class SourceController {
     private final CategoryService categoryService;
     //전체 카테고리 종류 조회
     @GetMapping("/tag")
+<<<<<<< HEAD
     public ResponseEntity<List<String>> getTags() {
         List<Category> categories = categoryService.getAllCategories();
         List<String> tags = categories.stream()
                 .map(category -> category.getCategoryName().toLowerCase(Locale.ROOT))
                 .toList();
         return ResponseEntity.ok(tags);
+=======
+    public ResponseEntity<List<CategoryDto.CategoryResponse>> getAllTags(){
+        return ResponseEntity.ok(categoryService.getAllCategories());
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     }
 }

--- a/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
@@ -1,9 +1,7 @@
 package com.schnofiticationbe.dto;
 
-<<<<<<< HEAD
-=======
+
 import com.schnofiticationbe.entity.Category;
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,11 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor // 기본 생성자
 @AllArgsConstructor
 
-<<<<<<< HEAD
-class CategoryDto {
-=======
 public class CategoryDto {
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     private Long id;
     private String categoryName;
 
@@ -28,23 +22,15 @@ public class CategoryDto {
     public static class UpdateRequest {
         private String categoryName;
     }
-<<<<<<< HEAD
-=======
+
     @Getter
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     public static class CategoryResponse {
         private Long id;
         private String categoryName;
 
-<<<<<<< HEAD
-        public CategoryResponse(Long id, String categoryName) {
-            this.id = id;
-            this.categoryName = categoryName;
-=======
         public CategoryResponse(Category category) {
             this.id = category.getId();
             this.categoryName = category.getCategoryName();
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
         }
     }
 

--- a/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
@@ -1,5 +1,9 @@
 package com.schnofiticationbe.dto;
 
+<<<<<<< HEAD
+=======
+import com.schnofiticationbe.entity.Category;
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +14,11 @@ import lombok.Setter;
 @NoArgsConstructor // 기본 생성자
 @AllArgsConstructor
 
+<<<<<<< HEAD
 class CategoryDto {
+=======
+public class CategoryDto {
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     private Long id;
     private String categoryName;
 
@@ -20,13 +28,23 @@ class CategoryDto {
     public static class UpdateRequest {
         private String categoryName;
     }
+<<<<<<< HEAD
+=======
+    @Getter
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     public static class CategoryResponse {
         private Long id;
         private String categoryName;
 
+<<<<<<< HEAD
         public CategoryResponse(Long id, String categoryName) {
             this.id = id;
             this.categoryName = categoryName;
+=======
+        public CategoryResponse(Category category) {
+            this.id = category.getId();
+            this.categoryName = category.getCategoryName();
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
         }
     }
 

--- a/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/CategoryDto.java
@@ -1,0 +1,33 @@
+package com.schnofiticationbe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor
+
+class CategoryDto {
+    private Long id;
+    private String categoryName;
+
+    public static class CreateRequest {
+        private String categoryName;
+    }
+    public static class UpdateRequest {
+        private String categoryName;
+    }
+    public static class CategoryResponse {
+        private Long id;
+        private String categoryName;
+
+        public CategoryResponse(Long id, String categoryName) {
+            this.id = id;
+            this.categoryName = categoryName;
+        }
+    }
+
+}

--- a/src/main/java/com/schnofiticationbe/dto/KakaoRoomInfoDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/KakaoRoomInfoDto.java
@@ -1,0 +1,48 @@
+package com.schnofiticationbe.dto;
+
+import com.schnofiticationbe.entity.KakaoRoomInfo;
+import lombok.*;
+
+public class KakaoRoomInfoDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateKakaoRoomInfoRequest {
+        private Long lessonId;
+        private String targetYear;
+        private String roomName;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateKakaoRoomInfoRequest {
+        private Long lessonId;
+        private String targetYear;
+        private String roomName;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class KakaoRoomInfoResponse {
+        private Long id;
+        private Long lessonId;
+        private String targetYear;
+        private String roomName;
+
+        public KakaoRoomInfoResponse(KakaoRoomInfo kakaoRoomInfo) {
+            this.id = kakaoRoomInfo.getId();
+            this.lessonId = kakaoRoomInfo.getLessonId();
+            this.targetYear = kakaoRoomInfo.getTargetYear().toString();
+            this.roomName = kakaoRoomInfo.getRoomName();
+        }
+    }
+}

--- a/src/main/java/com/schnofiticationbe/entity/Category.java
+++ b/src/main/java/com/schnofiticationbe/entity/Category.java
@@ -22,20 +22,9 @@ public class Category {
     @Schema(description = "카테고리 이름", example = "공지사항")
     private String categoryName;
 
-<<<<<<< HEAD
-    @OneToMany(mappedBy = "category")
-    private Set<FetchedNotice> fetchedNotices = new LinkedHashSet<>();
-
-=======
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     @Builder
     public Category(String categoryName) {
         this.categoryName = categoryName;
     }
 
-<<<<<<< HEAD
-
-
-=======
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 }

--- a/src/main/java/com/schnofiticationbe/entity/Category.java
+++ b/src/main/java/com/schnofiticationbe/entity/Category.java
@@ -1,0 +1,35 @@
+package com.schnofiticationbe.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+
+    @Schema(description = "카테고리 이름", example = "공지사항")
+    private String categoryName;
+
+    @OneToMany(mappedBy = "category")
+    private Set<FetchedNotice> fetchedNotices = new LinkedHashSet<>();
+
+    @Builder
+    public Category(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+
+
+}

--- a/src/main/java/com/schnofiticationbe/entity/Category.java
+++ b/src/main/java/com/schnofiticationbe/entity/Category.java
@@ -22,14 +22,20 @@ public class Category {
     @Schema(description = "카테고리 이름", example = "공지사항")
     private String categoryName;
 
+<<<<<<< HEAD
     @OneToMany(mappedBy = "category")
     private Set<FetchedNotice> fetchedNotices = new LinkedHashSet<>();
 
+=======
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     @Builder
     public Category(String categoryName) {
         this.categoryName = categoryName;
     }
 
+<<<<<<< HEAD
 
 
+=======
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 }

--- a/src/main/java/com/schnofiticationbe/entity/CrawlPosts.java
+++ b/src/main/java/com/schnofiticationbe/entity/CrawlPosts.java
@@ -25,6 +25,4 @@ public class CrawlPosts extends Notice {
     @Column()
     private int categoryId;
 
-    @Column()
-    private String postTime;
 }

--- a/src/main/java/com/schnofiticationbe/entity/KakaoRoomInfo.java
+++ b/src/main/java/com/schnofiticationbe/entity/KakaoRoomInfo.java
@@ -1,11 +1,16 @@
 package com.schnofiticationbe.entity;
 
+import com.schnofiticationbe.dto.KakaoRoomInfoDto;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class KakaoRoomInfo {
 
     @Id
@@ -21,6 +26,14 @@ public class KakaoRoomInfo {
     private InternalNotice.TargetYear targetYear;
 
     @Setter
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String roomName;
+
+    public static KakaoRoomInfo from(KakaoRoomInfoDto.CreateKakaoRoomInfoRequest dto) {
+        KakaoRoomInfo entity = new KakaoRoomInfo();
+        entity.lessonId = dto.getLessonId();
+        entity.targetYear = InternalNotice.TargetYear.valueOf(dto.getTargetYear());
+        entity.roomName = dto.getRoomName();
+        return entity;
+    }
 }

--- a/src/main/java/com/schnofiticationbe/repository/CategoryRepository.java
+++ b/src/main/java/com/schnofiticationbe/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.schnofiticationbe.repository;
+
+import com.schnofiticationbe.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/schnofiticationbe/repository/KakaoRoomInfoRepository.java
+++ b/src/main/java/com/schnofiticationbe/repository/KakaoRoomInfoRepository.java
@@ -1,0 +1,13 @@
+package com.schnofiticationbe.repository;
+
+import com.schnofiticationbe.entity.InternalNotice;
+import com.schnofiticationbe.entity.KakaoRoomInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KakaoRoomInfoRepository extends JpaRepository<KakaoRoomInfo,Long> {
+    List<KakaoRoomInfo> findByLessonIdAndTargetYear(Long lessonId, InternalNotice.TargetYear  targetYear);
+    List<KakaoRoomInfo> findAllByLessonId(Long lessonId);
+}

--- a/src/main/java/com/schnofiticationbe/security/SecurityConfig.java
+++ b/src/main/java/com/schnofiticationbe/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/swagger-ui/**", "/api/api-docs").permitAll()
                         .requestMatchers("/api/health/**").permitAll()
                         .requestMatchers("/api/subscribe/**").permitAll()
+                        .requestMatchers("/api/kakao/**").permitAll()
                         .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/schnofiticationbe/service/CategoryService.java
+++ b/src/main/java/com/schnofiticationbe/service/CategoryService.java
@@ -1,10 +1,8 @@
 package com.schnofiticationbe.service;
 
-<<<<<<< HEAD
-=======
+
 import com.schnofiticationbe.dto.CategoryDto;
 import com.schnofiticationbe.dto.CategoryDto.CategoryResponse;
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 import com.schnofiticationbe.entity.Category;
 import com.schnofiticationbe.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +16,11 @@ import java.util.List;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
 
-<<<<<<< HEAD
-    public List<Category> getAllCategories() {
-        return categoryRepository.findAll();
-=======
+
     public List<CategoryResponse> getAllCategories() {
         return categoryRepository.findAll()
                 .stream()
                 .map(CategoryDto.CategoryResponse::new)
                 .toList();
->>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     }
 }

--- a/src/main/java/com/schnofiticationbe/service/CategoryService.java
+++ b/src/main/java/com/schnofiticationbe/service/CategoryService.java
@@ -1,0 +1,19 @@
+package com.schnofiticationbe.service;
+
+import com.schnofiticationbe.entity.Category;
+import com.schnofiticationbe.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/schnofiticationbe/service/CategoryService.java
+++ b/src/main/java/com/schnofiticationbe/service/CategoryService.java
@@ -1,5 +1,10 @@
 package com.schnofiticationbe.service;
 
+<<<<<<< HEAD
+=======
+import com.schnofiticationbe.dto.CategoryDto;
+import com.schnofiticationbe.dto.CategoryDto.CategoryResponse;
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
 import com.schnofiticationbe.entity.Category;
 import com.schnofiticationbe.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +18,15 @@ import java.util.List;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
 
+<<<<<<< HEAD
     public List<Category> getAllCategories() {
         return categoryRepository.findAll();
+=======
+    public List<CategoryResponse> getAllCategories() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(CategoryDto.CategoryResponse::new)
+                .toList();
+>>>>>>> 0a5c4b4 (feat : 카테고리 종류 조회 api 추가)
     }
 }

--- a/src/main/java/com/schnofiticationbe/service/KakaoRoomInfoService.java
+++ b/src/main/java/com/schnofiticationbe/service/KakaoRoomInfoService.java
@@ -1,0 +1,79 @@
+package com.schnofiticationbe.service;
+
+import com.schnofiticationbe.dto.KakaoRoomInfoDto;
+import com.schnofiticationbe.entity.InternalNotice;
+import com.schnofiticationbe.entity.KakaoRoomInfo;
+import com.schnofiticationbe.repository.KakaoRoomInfoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoRoomInfoService {
+    private final KakaoRoomInfoRepository kakaoRoomInfoRepository;
+
+    // CREATE KakaoRoom
+    @Transactional
+    public KakaoRoomInfoDto.KakaoRoomInfoResponse createKakaoRoomInfo(KakaoRoomInfoDto.CreateKakaoRoomInfoRequest request) {
+        KakaoRoomInfo newKakaoRoomInfo = KakaoRoomInfo.from(request);
+        KakaoRoomInfo savedInfo=kakaoRoomInfoRepository.save(newKakaoRoomInfo);
+        return new KakaoRoomInfoDto.KakaoRoomInfoResponse(savedInfo);
+    }
+
+    // READ by ID
+    @Transactional(readOnly = true)
+    public KakaoRoomInfoDto.KakaoRoomInfoResponse findKakaoRoomInfoById(Long id) {
+        KakaoRoomInfo kakaoRoomInfo = kakaoRoomInfoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("KakaoRoomInfo not found with id: " + id));
+        return new KakaoRoomInfoDto.KakaoRoomInfoResponse(kakaoRoomInfo);
+    }
+
+    // UPDATE
+    @Transactional
+    public KakaoRoomInfoDto.KakaoRoomInfoResponse updateKakaoRoomInfo(Long id, KakaoRoomInfoDto.UpdateKakaoRoomInfoRequest request) {
+        KakaoRoomInfo existingKakaoRoomInfo = kakaoRoomInfoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("KakaoRoomInfo not found with id: " + id));
+
+        existingKakaoRoomInfo.setLessonId(request.getLessonId());
+        existingKakaoRoomInfo.setTargetYear(InternalNotice.TargetYear.valueOf(request.getTargetYear()));
+
+        KakaoRoomInfo updatedInfo = kakaoRoomInfoRepository.save(existingKakaoRoomInfo);
+        return new KakaoRoomInfoDto.KakaoRoomInfoResponse(updatedInfo);
+    }
+
+    // DELETE
+    @Transactional
+    public void deleteKakaoRoomInfo(Long id) {
+        if (!kakaoRoomInfoRepository.existsById(id)) {
+            throw new EntityNotFoundException("KakaoRoomInfo not found with id: " + id);
+        }
+        kakaoRoomInfoRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<KakaoRoomInfoDto.KakaoRoomInfoResponse> findRoomsByCriteria(InternalNotice.TargetYear targetYear, Long lessonId) {
+        List<KakaoRoomInfo> results;
+
+        if (lessonId != null && targetYear != null) {
+            // 1. lessonId와 targetYear가 모두 있는 경우
+            results = kakaoRoomInfoRepository.findByLessonIdAndTargetYear(lessonId, targetYear);
+        } else if (lessonId != null) {
+            // 2. lessonId만 있는 경우
+            results = kakaoRoomInfoRepository.findAllByLessonId(lessonId);
+        } else {
+            // 3. 파라미터가 모두 없는 경우 (getAll)
+            results = kakaoRoomInfoRepository.findAll();
+        }
+
+        // 조회된 Entity 리스트를 DTO 리스트로 변환하여 반환
+        return results.stream()
+                .map(KakaoRoomInfoDto.KakaoRoomInfoResponse::new)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
학년이 아닌 학번에 따라서 방이 생성되어 있어 기존 unique로 선언되어있던 방을 중복가능하게 만들어 한 학번카톡방에서 여러 학년들이 공지를 볼 수 있도록 수정 (22학번 공지방에 3,4,학년이 동시에 존재)