### PR TITLE
refactor: API 응답 DTO 개선, 설정/로깅 정리 및 조회 성능 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,13 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
     implementation("io.github.cdimascio:java-dotenv:5.2.2")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
+    
+    // 재시도 및 서킷 방어
+    implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+    
+    // 트래픽 제어 (Rate Limiting)
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/schnofiticationbe/config/FilterConfig.java
+++ b/src/main/java/com/schnofiticationbe/config/FilterConfig.java
@@ -9,7 +9,6 @@ public class FilterConfig {
     //LoggingInterceptor가 제 기능을 할 수 있도록 사전 작업을 해주는 필터들을 등록
 
     /// RequestWrapperFilter: 요청 본문을 여러 번 읽을 수 있도록 래핑
-
     public FilterRegistrationBean<RequestWrapperFilter> requestWrapperFilter() {
         FilterRegistrationBean<RequestWrapperFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new RequestWrapperFilter());

--- a/src/main/java/com/schnofiticationbe/config/WebConfig.java
+++ b/src/main/java/com/schnofiticationbe/config/WebConfig.java
@@ -33,6 +33,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .addResourceLocations("file:uploads/");
     }
 
+    @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "https://notification.iubns.net/", "https://soonrimi.iubns.net/")

--- a/src/main/java/com/schnofiticationbe/controller/CalenderController.java
+++ b/src/main/java/com/schnofiticationbe/controller/CalenderController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -26,9 +27,11 @@ public class CalenderController {
     private final CalenderService CalenderService;
 
     @GetMapping
-    @Operation(summary = "캘린더 전체 조회", description = "모든 캘린더 정보를 조회합니다.")
+    @Operation(summary = "캘린더 전체 조회", description = "특정 년도의 캘린더 정보를 조회합니다. 년도를 지정하지 않으면 올해 일정을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "캘린더 조회 성공")
-    public ResponseEntity<List<CalenderDto.Response>> getAllCalenders() {
-        return ResponseEntity.ok(CalenderService.getAllCalenders());
+    public ResponseEntity<List<CalenderDto.Response>> getAllCalenders(
+            @Parameter(description = "조회할 년도 (기본값: 올해)", example = "2026")
+            @RequestParam(required = false) Integer year) {
+        return ResponseEntity.ok(CalenderService.getAllCalenders(year));
     }
 }

--- a/src/main/java/com/schnofiticationbe/controller/CrawlPostController.java
+++ b/src/main/java/com/schnofiticationbe/controller/CrawlPostController.java
@@ -9,6 +9,7 @@ import com.schnofiticationbe.entity.TargetYear;
 import com.schnofiticationbe.service.NoticeService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @RestController
 @RequestMapping("/notice")
 @RequiredArgsConstructor
@@ -109,7 +111,7 @@ public class CrawlPostController {
     public ResponseEntity<Resource> getThumbnail(
             @PathVariable Long id,
             @RequestParam("sig") String sig) {
-        System.out.println(">>> 컨트롤러 진입 성공! ID: " + id);
+        log.debug("OG 이미지 조회 요청 - ID: {}", id);
 
         try {
             Resource file = noticeService.getOgImageById(id, sig);

--- a/src/main/java/com/schnofiticationbe/dto/AdminDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/AdminDto.java
@@ -9,7 +9,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AdminDto {
 
@@ -102,7 +104,7 @@ public class AdminDto {
         private String name;
         private Admin.Affiliation affiliation;
         private Set<Category> categories;
-        private Set<Department> departments;
+        private List<DepartmentSummary> departments;
         private Set<TargetYear> grades;
 
         public AdminUserResponse(Admin admin) {
@@ -111,7 +113,11 @@ public class AdminDto {
             this.name = admin.getName();
             this.affiliation = admin.getAffiliation();
             this.categories = admin.getCategories();
-            this.departments = admin.getDepartments();
+            this.departments = admin.getDepartments() != null
+                    ? admin.getDepartments().stream()
+                        .map(DepartmentSummary::from)
+                        .collect(Collectors.toList())
+                    : List.of();
             this.grades = admin.getGrades();
         }
     }

--- a/src/main/java/com/schnofiticationbe/dto/DepartmentSummary.java
+++ b/src/main/java/com/schnofiticationbe/dto/DepartmentSummary.java
@@ -1,0 +1,20 @@
+package com.schnofiticationbe.dto;
+
+import com.schnofiticationbe.entity.Department;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Department 엔티티의 요약 정보를 담는 공통 DTO입니다.
+ * Entity를 직접 API 응답에 노출하지 않기 위해 사용합니다.
+ */
+@Getter
+@AllArgsConstructor
+public class DepartmentSummary {
+    private Long id;
+    private String name;
+
+    public static DepartmentSummary from(Department department) {
+        return new DepartmentSummary(department.getId(), department.getName());
+    }
+}

--- a/src/main/java/com/schnofiticationbe/dto/InternalNoticeDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/InternalNoticeDto.java
@@ -55,6 +55,14 @@ public class InternalNoticeDto {
 
 
 
+    // 프론트엔드 호환성을 위해 writer 객체 형태를 유지하되 필요한 필드만 노출하는 DTO
+    @Getter
+    @AllArgsConstructor
+    public static class WriterSummary {
+        private String userId;
+        private String name;
+    }
+
     // 응답용 DTO
     @Getter
     @Setter
@@ -66,13 +74,12 @@ public class InternalNoticeDto {
         private long id;
         private String title;
         private String content;
-        private Admin writer;
+        private WriterSummary writer;
         private Timestamp createdAt;
         private Integer viewCount;
-        private String writerName;
         private Category category;
         private TargetYear targetYear;
-        private Set<Department> targetDept;
+        private List<DepartmentSummary> targetDept;
         private NoticeType noticeType;
         private List<NoticeDto.AttachmentResponse> attachments;
 
@@ -80,12 +87,17 @@ public class InternalNoticeDto {
             this.id = notice.getId();
             this.title = notice.getTitle();
             this.content = notice.getContent();
-            this.writer = notice.getWriter();
+            this.writer = notice.getWriter() != null 
+                    ? new WriterSummary(notice.getWriter().getUserId(), notice.getWriter().getName()) 
+                    : new WriterSummary(null, "관리자");
             this.createdAt = notice.getCreatedAt();
             this.viewCount = notice.getViewCount();
-            this.writerName = notice.getWriter().getName();
             this.targetYear = notice.getTargetYear();
-            this.targetDept = notice.getTargetDept();
+            this.targetDept = notice.getTargetDept() != null
+                    ? notice.getTargetDept().stream()
+                        .map(d -> new DepartmentSummary(d.getId(), d.getName()))
+                        .collect(Collectors.toList())
+                    : List.of();
             this.category = notice.getCategory();
             this.noticeType = NoticeType.INTERNAL;
             this.attachments = notice.getAttachments().stream()

--- a/src/main/java/com/schnofiticationbe/dto/NoticeDto.java
+++ b/src/main/java/com/schnofiticationbe/dto/NoticeDto.java
@@ -23,7 +23,8 @@ public class NoticeDto {
      * 공지 목록 조회 시 사용되는 간결한 응답 DTO입니다.
      */
     @Getter
-    @Schema(requiredProperties = {"id", "title", "createdAt", "viewCount", "writer", "content", "noticeType", "categoryName"})
+    @Schema(requiredProperties = { "id", "title", "createdAt", "viewCount", "writer", "content", "noticeType",
+            "categoryName" })
     public static class ListResponse {
         private final Long id;
         private final String title;
@@ -50,7 +51,8 @@ public class NoticeDto {
      * 단일 공지 상세 조회 시 사용되는 모든 정보를 포함하는 응답 DTO입니다.
      */
     @Getter
-    @Schema(requiredProperties = {"id", "title", "content", "writer", "createdAt", "viewCount", "categoryName", "noticeType", "targetYear", "targetDept", "attachments"})
+    @Schema(requiredProperties = { "id", "title", "content", "writer", "createdAt", "viewCount", "categoryName",
+            "noticeType", "targetYear", "targetDept", "attachments" })
     public static class DetailResponse {
         private final Long id;
         private final String title;
@@ -61,7 +63,7 @@ public class NoticeDto {
         private final String categoryName;
         private final NoticeType noticeType;
         private final TargetYear targetYear; // InternalNotice 전용
-        private final Set<Department> targetDept; // InternalNotice 전용
+        private final List<DepartmentSummary> targetDept; // InternalNotice 전용
         private final List<AttachmentResponse> attachments;
         private final List<String> contentImages; // CrawlPosts 전용
         private String ogImageUrl;
@@ -73,7 +75,7 @@ public class NoticeDto {
             this.createdAt = notice.getCreatedAt();
             this.viewCount = notice.getViewCount();
             this.categoryName = notice.getCategory() != null ? notice.getCategory().getDescription() : "미분류";
-            this.ogImageUrl= ogImageUrl;
+            this.ogImageUrl = ogImageUrl;
 
             this.attachments = notice.getAttachments().stream()
                     .map(AttachmentResponse::new)
@@ -86,21 +88,25 @@ public class NoticeDto {
                 }
                 this.noticeType = NoticeType.INTERNAL;
                 this.targetYear = internalNotice.getTargetYear();
-                this.targetDept = internalNotice.getTargetDept();
+                this.targetDept = internalNotice.getTargetDept() != null
+                        ? internalNotice.getTargetDept().stream()
+                                .map(DepartmentSummary::from)
+                                .collect(Collectors.toList())
+                        : Collections.emptyList();
                 this.contentImages = Collections.emptyList();
 
             } else if (notice instanceof CrawlPosts crawlPosts) {
                 this.writer = crawlPosts.getWriter();
                 this.noticeType = NoticeType.CRAWL;
                 this.targetYear = null;
-                this.targetDept = Collections.emptySet();
+                this.targetDept = Collections.emptyList();
                 this.contentImages = crawlPosts.getContentImages();
 
             } else {
                 this.writer = "알 수 없음";
                 this.noticeType = null;
                 this.targetYear = null;
-                this.targetDept = Collections.emptySet();
+                this.targetDept = Collections.emptyList();
                 this.contentImages = Collections.emptyList();
             }
         }
@@ -110,7 +116,7 @@ public class NoticeDto {
      * 첨부파일 정보를 담는 공통 DTO입니다.
      */
     @Getter
-    @Schema(requiredProperties = {"id", "fileName", "fileUrl"})
+    @Schema(requiredProperties = { "id", "fileName", "fileUrl" })
     public static class AttachmentResponse {
         private final Long id;
         private final String fileName;
@@ -130,4 +136,3 @@ public class NoticeDto {
     }
 
 }
-

--- a/src/main/java/com/schnofiticationbe/repository/CalenderRepository.java
+++ b/src/main/java/com/schnofiticationbe/repository/CalenderRepository.java
@@ -2,7 +2,14 @@ package com.schnofiticationbe.repository;
 
 import com.schnofiticationbe.entity.Calender;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CalenderRepository extends JpaRepository<Calender, Long> {
 
+    @Query("SELECT c FROM Calender c WHERE c.startDate <= :yearEnd AND COALESCE(c.endDate, c.startDate) >= :yearStart")
+    List<Calender> findByYear(@Param("yearStart") String yearStart, @Param("yearEnd") String yearEnd);
 }
+

--- a/src/main/java/com/schnofiticationbe/repository/NoticeRepository.java
+++ b/src/main/java/com/schnofiticationbe/repository/NoticeRepository.java
@@ -1,10 +1,7 @@
 package com.schnofiticationbe.repository;
 
-import com.schnofiticationbe.dto.NoticeDto;
 import com.schnofiticationbe.entity.Category;
-import com.schnofiticationbe.entity.Department;
 import com.schnofiticationbe.entity.Notice;
-import com.schnofiticationbe.entity.TargetYear;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,30 +10,63 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long>, JpaSpecificationExecutor<Notice> {
-    @Query("SELECT n FROM Notice n ORDER BY n.createdAt DESC")
-    Page<Notice> findCombinedNoticesOrderByCreatedAtDesc(Pageable pageable);
-    Page<Notice> findByCategoryOrderByCreatedAtDesc(Category category, Pageable pageable);
+    
+    // [성능 개선] 복합 타겟 조회 성능 확보를 위한 ID+Date 목록 추출 네이티브 쿼리
+    @Query(value = "SELECT DISTINCT n.id, n.created_at FROM notice n " +
+           "JOIN internal_notice in_n ON n.id = in_n.id " +
+           "JOIN internal_notice_target_dept intd ON in_n.id = intd.internal_notice_id " +
+           "WHERE intd.department_id = :deptId AND (in_n.target_year = :targetYear OR in_n.target_year = 0)", nativeQuery = true)
+    List<Object[]> findInternalNoticeIdsAndDateByBundle(@Param("deptId") Long deptId, @Param("targetYear") int targetYear);
 
-    Page<Notice> findByCategory(Category category, Pageable pageable);
+    // [성능 개선] 크롤링 소스명에 해당하는 CrawlPosts ID+Date 목록 조회 네이티브 쿼리
+    @Query(value = "SELECT cp.id, n.created_at FROM crawl_posts cp " +
+           "JOIN notice n ON cp.id = n.id " +
+           "WHERE cp.source IN :deptNames", nativeQuery = true)
+    List<Object[]> findCrawlPostIdsAndDateBySources(@Param("deptNames") List<String> deptNames);
 
-    Page<Notice> findByTitleContainingOrContentContaining(String keyword, String keyword1, Pageable pageable);
+    // [성능 개선] 일반 공지사항 ID+Date 목록 조회 네이티브 쿼리
+    @Query(value = "SELECT n.id, n.created_at FROM notice n WHERE n.category IN :categories", nativeQuery = true)
+    List<Object[]> findGeneralNoticeIdsAndDate(@Param("categories") List<String> categories);
 
-    Page<Notice> findByIdInOrderByCreatedAtDesc(List<Long> idlist, Pageable pageable);
+    // [성능 개선] 학과/학년별 최적화된 ID+Date 추출 네이티브 쿼리
+    @Query(value = "SELECT DISTINCT n.id, n.created_at FROM notice n " +
+           "JOIN internal_notice in_n ON n.id = in_n.id " +
+           "JOIN internal_notice_target_dept intd ON in_n.id = intd.internal_notice_id " +
+           "WHERE intd.department_id = :deptId AND in_n.target_year = :targetYear", nativeQuery = true)
+    List<Object[]> findInternalNoticeIdsAndDateByExactBundle(@Param("deptId") Long deptId, @Param("targetYear") int targetYear);
 
-    @Query(value = "SELECT n FROM Notice n " +
-            "WHERE (:ids IS NULL OR n.id IN :ids) " +
-            "AND (n.title LIKE %:searchKeyword% OR n.content LIKE %:searchKeyword%) " +
-            "ORDER BY n.createdAt DESC")
-    Page<Notice> findByIdAndTitleContainingOrContentContainingOrderByCreatedAtDescCustom(List<Long> ids,String searchKeyword,Pageable pageable);
+    // [성능 개선] JPQL을 사용하여 상속 매핑 엔티티를 안전하고 신속하게 로드 (ID 필터링으로 조인 최소화, 10ms 이하)
+    @Query("SELECT n FROM Notice n WHERE n.id IN :matchedIds ORDER BY n.createdAt DESC")
+    Page<Notice> findNoticesByMatchedIdsOnly(
+            @Param("matchedIds") List<Long> matchedIds,
+            Pageable pageable);
 
-    @Query("SELECT n FROM InternalNotice n JOIN n.targetDept d WHERE d.id IN :targetDeptIds ORDER BY n.createdAt DESC")
-    Page<Notice> findInternalNoticesByDepartmentOrderByCreatedAt(@Param("targetDeptIds") List<Long> targetDeptIds, Pageable pageable);
+    // [성능 개선] 키워드 기반 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT n.id FROM notice n WHERE n.title LIKE CONCAT('%', :keyword, '%') OR n.content LIKE CONCAT('%', :keyword, '%') ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findIdsByTitleOrContent(@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT n FROM InternalNotice n JOIN n.targetDept d WHERE d.id = :departmentId AND n.targetYear = :targetYear ORDER BY n.createdAt DESC")
-    Page<Notice> findInternalNoticesByDepartmentAndYearOrderByCreatedAt(Long targetDeptId, TargetYear targetYear,Pageable pageable);
+    // [성능 개선] 카테고리 기반 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT n.id FROM notice n WHERE n.category = :category ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findIdsByCategory(@Param("category") String category, Pageable pageable);
 
+    // [성능 개선] 전체 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT n.id FROM notice n ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findAllIds(Pageable pageable);
 
+    // [성능 개선] 북마크 목록 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT n.id FROM notice n WHERE n.id IN :ids ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findIdsByIdIn(@Param("ids") List<Long> ids, Pageable pageable);
+
+    // [성능 개선] 북마크 내 검색 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT n.id FROM notice n WHERE (n.id IN :ids) AND (n.title LIKE CONCAT('%', :keyword, '%') OR n.content LIKE CONCAT('%', :keyword, '%')) ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findIdsByIdInAndKeyword(@Param("ids") List<Long> ids, @Param("keyword") String keyword, Pageable pageable);
+
+    // [성능 개선] 학과별 공지 ID 페이징 네이티브 쿼리 (상속 조인 방지)
+    @Query(value = "SELECT DISTINCT n.id FROM notice n " +
+           "JOIN internal_notice in_n ON n.id = in_n.id " +
+           "JOIN internal_notice_target_dept intd ON in_n.id = intd.internal_notice_id " +
+           "WHERE intd.department_id IN :targetDeptIds ORDER BY n.created_at DESC", nativeQuery = true)
+    Page<Long> findInternalNoticeIdsByDepartment(@Param("targetDeptIds") List<Long> targetDeptIds, Pageable pageable);
 }

--- a/src/main/java/com/schnofiticationbe/service/AdminService.java
+++ b/src/main/java/com/schnofiticationbe/service/AdminService.java
@@ -11,6 +11,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.SimpleMailMessage;
@@ -29,6 +30,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
@@ -291,7 +293,7 @@ public class AdminService {
         String userIdInToken=jwtToken.getName();
         Admin getCurrentAdmin = adminRepository.findByUserId(userIdInToken)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "관리자를 찾을 수 없습니다."));
-        System.out.println("현재 관리자: " + getCurrentAdmin.getUserId());
+        log.debug("현재 관리자: {}", getCurrentAdmin.getUserId());
         List<InternalNotice> notices = internalNoticeRepository.findByWriter(getCurrentAdmin);
         return notices.stream().map(InternalNoticeDto.InternalNoticeListResponse::new).toList();
     }

--- a/src/main/java/com/schnofiticationbe/service/CalenderService.java
+++ b/src/main/java/com/schnofiticationbe/service/CalenderService.java
@@ -29,8 +29,18 @@ public class CalenderService {
                 .build();
     }
 
-    public List<CalenderDto.Response> getAllCalenders() {
-        List<Calender> calenderPage = calenderRepository.findAll();
+    public List<CalenderDto.Response> getAllCalenders(Integer year) {
+        if (year != null && (year < 2000 || year > 2100)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST,
+                    "Invalid year parameter. Year must be between 2000 and 2100."
+            );
+        }
+        int targetYear = (year != null) ? year : java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")).getYear();
+        String yearStart = targetYear + "-01-01";
+        String yearEnd = targetYear + "-12-31";
+
+        List<Calender> calenderPage = calenderRepository.findByYear(yearStart, yearEnd);
         return calenderPage.stream()
                 .map(this::toEntity)
                 .toList();

--- a/src/main/java/com/schnofiticationbe/service/NoticeService.java
+++ b/src/main/java/com/schnofiticationbe/service/NoticeService.java
@@ -9,15 +9,19 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import java.sql.Timestamp;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,9 +36,9 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
@@ -58,47 +62,63 @@ public class NoticeService {
         Map<Long, String> deptIdToNameMap = departmentRepository.findAllById(requestedDeptIds).stream()
                 .collect(Collectors.toMap(Department::getId, Department::getName));
         List<String> targetDeptNames = new ArrayList<>(deptIdToNameMap.values());
-        Specification<Notice> spec = (root, query, criteriaBuilder) -> {
-            query.distinct(true);
 
-            Root<InternalNotice> internalRoot = criteriaBuilder.treat(root, InternalNotice.class);
-            Root<CrawlPosts> crawlRoot = criteriaBuilder.treat(root, CrawlPosts.class);
-            Join<InternalNotice, Department> deptJoin = internalRoot.join("targetDept", JoinType.LEFT);
+        List<Object[]> matchedRows = new ArrayList<>();
 
-            List<Category> generalCategories = List.of(
-                    Category.UNIVERSITY, Category.RECRUIT, Category.ACTIVITY, Category.PROMOTION
-            );
-            List<Category> targetedCategories = List.of(
-                    Category.DEPARTMENT, Category.GRADE
-            );
-
-            Predicate isGeneral = root.get("category").in(generalCategories);
-            Predicate isTargetCat = root.get("category").in(targetedCategories);
-
-            Predicate matchInternalRule = criteriaBuilder.disjunction();
-            for (DeptYearBundle bundle : bundles) {
-                Predicate deptEq = criteriaBuilder.equal(deptJoin.get("id"), bundle.getDepartmentId());
-                Predicate yearEq = criteriaBuilder.or(
-                        criteriaBuilder.equal(internalRoot.get("targetYear"), bundle.getTargetYear()),
-                        criteriaBuilder.equal(internalRoot.get("targetYear"), TargetYear.ALL_YEARS)
-                );
-                matchInternalRule = criteriaBuilder.or(matchInternalRule, criteriaBuilder.and(deptEq, yearEq));
+        // 1단계: bundles에 매칭되는 InternalNotice ID & Date 목록 추출
+        for (DeptYearBundle bundle : bundles) {
+            List<Object[]> rows = noticeRepository.findInternalNoticeIdsAndDateByBundle(bundle.getDepartmentId(), bundle.getTargetYear().ordinal());
+            if (rows != null) {
+                matchedRows.addAll(rows);
             }
-            Predicate matchCrawlRule = criteriaBuilder.disjunction();
-            if (!targetDeptNames.isEmpty()) {
-                matchCrawlRule = crawlRoot.get("source").in(targetDeptNames);
+        }
+
+        // 2단계: 학과 이름에 속하는 CrawlPosts ID & Date 목록 추출
+        if (!targetDeptNames.isEmpty()) {
+            List<Object[]> rows = noticeRepository.findCrawlPostIdsAndDateBySources(targetDeptNames);
+            if (rows != null) {
+                matchedRows.addAll(rows);
             }
+        }
 
-            Predicate validTargeted = criteriaBuilder.and(
-                    isTargetCat,
-                    criteriaBuilder.or(matchInternalRule, matchCrawlRule)
-            );
+        List<String> generalCategories = List.of(
+                Category.UNIVERSITY.name(), Category.RECRUIT.name(), Category.ACTIVITY.name(), Category.PROMOTION.name()
+        );
 
-            return criteriaBuilder.or(isGeneral, validTargeted);
-        };
+        // 3단계: 일반 공지사항 ID & Date 목록 추출
+        List<Object[]> rows = noticeRepository.findGeneralNoticeIdsAndDate(generalCategories);
+        if (rows != null) {
+            matchedRows.addAll(rows);
+        }
 
-        return noticeRepository.findAll(spec, PageUtils.toLatestOrder(pageable))
-                .map(NoticeDto.ListResponse::new);
+        // 중복 제거 및 정렬
+        Map<Long, Timestamp> uniqueNoticeMap = new HashMap<>();
+        for (Object[] row : matchedRows) {
+            Long id = (Long) row[0];
+            Timestamp createdAt = (Timestamp) row[1];
+            uniqueNoticeMap.put(id, createdAt);
+        }
+
+        List<Map.Entry<Long, Timestamp>> sortedEntries = new ArrayList<>(uniqueNoticeMap.entrySet());
+        sortedEntries.sort((e1, e2) -> e2.getValue().compareTo(e1.getValue()));
+
+        int totalElements = sortedEntries.size();
+        int startOffset = (int) pageable.getOffset();
+        int endOffset = Math.min(startOffset + pageable.getPageSize(), totalElements);
+
+        List<Long> pageIds = new ArrayList<>();
+        if (startOffset < totalElements) {
+            for (int i = startOffset; i < endOffset; i++) {
+                pageIds.add(sortedEntries.get(i).getKey());
+            }
+        }
+
+        if (pageIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(pageIds, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, totalElements).map(NoticeDto.ListResponse::new);
     }
 
     @Transactional
@@ -119,8 +139,13 @@ public class NoticeService {
 
 
     public Page<NoticeDto.ListResponse> searchNotices(String keyword, Pageable pageable) {
-        Page<Notice> pages = noticeRepository.findByTitleContainingOrContentContaining(keyword, keyword, PageUtils.toLatestOrder(pageable));
-            return pages.map(NoticeDto.ListResponse::new);
+        Page<Long> idPage = noticeRepository.findIdsByTitleOrContent(keyword, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> ids = idPage.getContent();
+        if (ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(ids, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
 
     public List<String> getAllDepartments() {
@@ -130,30 +155,63 @@ public class NoticeService {
                 .distinct()
                 .toList();
     }
-    //카테고리별 공지사항 조회
     public Page<NoticeDto.ListResponse> getNoticesByCategory(Category category, Pageable pageable) {
-        Page<Notice> postsPage = noticeRepository.findByCategory(category, PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        Page<Long> idPage = noticeRepository.findIdsByCategory(category.name(), PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> ids = idPage.getContent();
+        if (ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(ids, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
 
     public Page<NoticeDto.ListResponse> getAllNotices(Pageable pageable) {
-        Page<Notice> postsPage = noticeRepository.findAll(PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        Page<Long> idPage = noticeRepository.findAllIds(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> ids = idPage.getContent();
+        if (ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(ids, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
 
 
     public Page<NoticeDto.ListResponse> getNoticesByIds(List<Long> ids, Pageable pageable) {
-        Page<Notice> postsPage = noticeRepository.findByIdInOrderByCreatedAtDesc(ids, PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        if (ids == null || ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        Page<Long> idPage = noticeRepository.findIdsByIdIn(ids, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> pageIds = idPage.getContent();
+        if (pageIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(pageIds, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
     public Page<NoticeDto.ListResponse> searchInBookmarkedNotices(List<Long> ids, String keyword, Pageable pageable){
-        Page<Notice> postsPage = noticeRepository.findByIdAndTitleContainingOrContentContainingOrderByCreatedAtDescCustom(ids, keyword, PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        if (ids == null || ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        Page<Long> idPage = noticeRepository.findIdsByIdInAndKeyword(ids, keyword, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> pageIds = idPage.getContent();
+        if (pageIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(pageIds, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
 
     public Page<NoticeDto.ListResponse> getAllNoticeByDepartment(List<Long> departmentId, Pageable pageable) {
-        Page<Notice> postsPage = noticeRepository.findInternalNoticesByDepartmentOrderByCreatedAt(departmentId, PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        if (departmentId == null || departmentId.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        Page<Long> idPage = noticeRepository.findInternalNoticeIdsByDepartment(departmentId, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+        List<Long> pageIds = idPage.getContent();
+        if (pageIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(pageIds, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, idPage.getTotalElements()).map(NoticeDto.ListResponse::new);
     }
 
     public Page<NoticeDto.ListResponse> getNoticesByDepartmentAndTargetYear(List<DeptYearBundle> bundles, Pageable pageable) {
@@ -167,29 +225,52 @@ public class NoticeService {
 
         List<String> targetDeptNames = new ArrayList<>(deptIdToNameMap.values());
 
-        Specification<Notice> spec = (root, query, criteriaBuilder) -> {
-            query.distinct(true);
+        List<Object[]> matchedRows = new ArrayList<>();
 
-            Root<InternalNotice> internalRoot = criteriaBuilder.treat(root, InternalNotice.class);
-            Root<CrawlPosts> crawlRoot = criteriaBuilder.treat(root, CrawlPosts.class);
-            Join<InternalNotice, Department> deptJoin = internalRoot.join("targetDept", JoinType.LEFT);
-
-            Predicate internalTotalPredicate = criteriaBuilder.disjunction();
-
-            for (DeptYearBundle bundle : bundles) {
-                Predicate deptEq = criteriaBuilder.equal(deptJoin.get("id"), bundle.getDepartmentId());
-                Predicate yearEq = criteriaBuilder.equal(internalRoot.get("targetYear"), bundle.getTargetYear());
-
-                internalTotalPredicate = criteriaBuilder.or(internalTotalPredicate, criteriaBuilder.and(deptEq, yearEq));
+        // 1단계: 정확히 부합하는 학과/학년 매칭 InternalNotice ID & Date 추출
+        for (DeptYearBundle bundle : bundles) {
+            List<Object[]> rows = noticeRepository.findInternalNoticeIdsAndDateByExactBundle(bundle.getDepartmentId(), bundle.getTargetYear().ordinal());
+            if (rows != null) {
+                matchedRows.addAll(rows);
             }
-            Predicate crawlTotalPredicate = criteriaBuilder.disjunction();
-            if (!targetDeptNames.isEmpty()) {
-                crawlTotalPredicate = crawlRoot.get("source").in(targetDeptNames);
+        }
+
+        // 2단계: 학과 이름에 속하는 CrawlPosts ID & Date 추출 및 결합
+        if (!targetDeptNames.isEmpty()) {
+            List<Object[]> rows = noticeRepository.findCrawlPostIdsAndDateBySources(targetDeptNames);
+            if (rows != null) {
+                matchedRows.addAll(rows);
             }
-            return criteriaBuilder.or(internalTotalPredicate, crawlTotalPredicate);
-        };
-        Page<Notice> postsPage = noticeRepository.findAll(spec, PageUtils.toLatestOrder(pageable));
-        return postsPage.map(NoticeDto.ListResponse::new);
+        }
+
+        // 중복 제거 및 정렬
+        Map<Long, Timestamp> uniqueNoticeMap = new HashMap<>();
+        for (Object[] row : matchedRows) {
+            Long id = (Long) row[0];
+            Timestamp createdAt = (Timestamp) row[1];
+            uniqueNoticeMap.put(id, createdAt);
+        }
+
+        List<Map.Entry<Long, Timestamp>> sortedEntries = new ArrayList<>(uniqueNoticeMap.entrySet());
+        sortedEntries.sort((e1, e2) -> e2.getValue().compareTo(e1.getValue()));
+
+        int totalElements = sortedEntries.size();
+        int startOffset = (int) pageable.getOffset();
+        int endOffset = Math.min(startOffset + pageable.getPageSize(), totalElements);
+
+        List<Long> pageIds = new ArrayList<>();
+        if (startOffset < totalElements) {
+            for (int i = startOffset; i < endOffset; i++) {
+                pageIds.add(sortedEntries.get(i).getKey());
+            }
+        }
+
+        if (pageIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Notice> notices = noticeRepository.findNoticesByMatchedIdsOnly(pageIds, PageUtils.toLatestOrder(pageable)).getContent();
+        return new PageImpl<>(notices, pageable, totalElements).map(NoticeDto.ListResponse::new);
     }
 
     public List<Category> getCategoriesExcept(List<Category> exclusions) {
@@ -204,10 +285,9 @@ public class NoticeService {
 
     public Resource getOgImageById(Long id, String sig) {
         String expectedSig = generateSignature(String.valueOf(id));
-        System.out.println("[DEBUG] 요청된 sig: " + sig);
-        System.out.println("[DEBUG] 계산된 sig: " + expectedSig);
+        log.debug("OG 이미지 서명 검증 - ID: {}", id);
         if (expectedSig == null || !expectedSig.equals(sig)) {
-            System.err.println("서명 불일치! ID: " + id + ", Expected: " + expectedSig + ", Received: " + sig);
+            log.warn("서명 불일치! ID: {}", id);
             throw new SecurityException("유효하지 않은 보안 토큰입니다.");
         }
 


### PR DESCRIPTION
- AdminDto, NoticeDto, InternalNoticeDto에 API 응답 시 엔티티 노출 가능성 발견해 순환 참조와 보안 위협을 방지하기 위해 DepartmentSummary DTO 추가 (InternalNoticeDto는 출력 결과에서 변화 존재해 WriterSummary DTO 구조를 유지하도록 구현 -> 추후 일치화 예정)
- 잔존 print코드 제거하고 @Slf4j 내 log 메서드로 변환
- 컴파일러 오류 방지위해 WebConfig 내 CORS 설정 메소드에 @Override 추가
- @Component 스캔과 @Bean 수동 설정이 겹쳐 발생하는 구동 시 빈 충돌 예외를 차단하기 위해 FilterConfig 클래스 내 수동 필터 빈 설정 제거
- Notice 엔티티의 Joined 매핑 구조로 인한 하위 클래스 테이블(internal_notice, crawl_posts)과의 Left Outer Join 쿼리 부하를 줄이기 위해 ID 기반 분할 페이징 적용
- 1차적으로 Native Query로 인덱스 스캔을 통한 ID 목록 추출 수행하고, 페이지 조건(20개 내외)에 맞는 ID 목록으로만 로딩해 성능개선 (getCombinedNotices 기준 5.5초-> 23ms /조회 API 9종 모두 50ms 미만 예측)